### PR TITLE
Add components for Headings

### DIFF
--- a/src/components/Text/Headings.tsx
+++ b/src/components/Text/Headings.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const Heading1: React.FC = ({ children }) => {
+  return (
+    <h1 className="mt-2 text-3xl font-extrabold leading-8 tracking-tight text-gray-900 sm:text-4xl">
+      {children}
+    </h1>
+  );
+};
+
+export const Heading2: React.FC = ({ children }) => {
+  return (
+    <h2 className="mt-2 text-xl font-bold text-gray-700 sm:text-2xl">
+      {children}
+    </h2>
+  );
+};
+
+export const Heading3: React.FC = ({ children }) => {
+  return <h3 className="mt-2 text-lg font-bold text-gray-700">{children}</h3>;
+};

--- a/src/components/Text/index.ts
+++ b/src/components/Text/index.ts
@@ -1,0 +1,1 @@
+export * from './Headings';


### PR DESCRIPTION
## Proposed changes

For easier usage and the default unstyled headings in tailwindCSS, we should have headings components

## Closes Issue
<!-- Add the issue which get resolved with this PR, if so  -->

Closes #35
