### PR TITLE
Delete renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "extends": ["config:base"],
-  "semanticCommits": true,
-  "stabilityDays": 3,
-  "prCreation": "not-pending",
-  "labels": ["type: dependencies"]
-}


### PR DESCRIPTION
This is left over from the gatsby starter (https://github.com/jpedroschmitz/gatsby-starter-ts). We are not using it.
