### PR TITLE
Display the number of RSVs on the overview page

### DIFF
--- a/src/pages/steckbriefe/index.tsx
+++ b/src/pages/steckbriefe/index.tsx
@@ -46,7 +46,7 @@ const SteckbriefeIndex: React.FC<PageProps & Props> = ({
               Trassenverläufe bzw. -korridore. Enthalten sind RSV aus Hessen,
               Baden-Württemberg, Berlin, Niedersachsen, Schleswig-Holstein,
               Mecklenburg-Vorpommern, Nordrhein-Westfalen, Rheinland-Pfalz und
-              Hamburg. Aktuel umfasst die Liste {radschnellwege.nodes.length}{' '}
+              Hamburg. Aktuell umfasst die Liste {radschnellwege.nodes.length}{' '}
               Radschnellverbindungen und wird fortlaufend erweitert.{' '}
               <p>
                 Mail an{' '}

--- a/src/pages/steckbriefe/index.tsx
+++ b/src/pages/steckbriefe/index.tsx
@@ -46,7 +46,8 @@ const SteckbriefeIndex: React.FC<PageProps & Props> = ({
               Trassenverläufe bzw. -korridore. Enthalten sind RSV aus Hessen,
               Baden-Württemberg, Berlin, Niedersachsen, Schleswig-Holstein,
               Mecklenburg-Vorpommern, Nordrhein-Westfalen, Rheinland-Pfalz und
-              Hamburg. Die Liste wird fortlaufend erweitert.
+              Hamburg. Aktuel umfasst die Liste {radschnellwege.nodes.length}{' '}
+              Radschnellverbindungen und wird fortlaufend erweitert.{' '}
               <p>
                 Mail an{' '}
                 <MailToButtonLink


### PR DESCRIPTION
This PR adds a text displaying the number of RSVs on the overview page.