### PR TITLE
Fix `state` attribute in GeoJSONs

### DIFF
--- a/data/rsv_meta.json
+++ b/data/rsv_meta.json
@@ -1,0 +1,28 @@
+[
+    {
+        "id": "rs1-baden-w\u00fcrttemberg",
+        "cost": "drei Millionen Euro",
+        "finished": "",
+        "state": "in_progress",
+        "general": {
+            "ref": "RS1",
+            "name": "Radschnellweg B\u00f6blingen/Sindelfingen  \u2013 Stuttgart",
+            "from": "B\u00f6blingen",
+            "to": "Stuttgart",
+            "length": "20",
+            "description": "Anbindung der St\u00e4dte B\u00f6blingen und Sindelfingen f\u00fcr Radpendler an das Oberzentrum Stuttgart. In einem Bauabschnitt von acht Kilometern L\u00e4nge wurde die gepflasterte R\u00f6merstra\u00dfe auf vier Meter Breite asphaltiert und mit einer Beleuchtung versehen. Der Ausbau kostete drei Millionen Euro und wurde im Fr\u00fchjahr 2019 fertiggestellt. Der Sindelfinger Zweig f\u00fchrt von der Mahdentalstra\u00dfe \u00fcber den M\u00f6nchsbrunnen und das Musberger Str\u00e4\u00dfle bis zur R\u00f6merstra\u00dfe. Auf 80 Meter Strecke bleibt aus Gr\u00fcnden des Denkmalschutzes das historische Pflaster sichtbar. In Planung: eine bessere \u00dcberquerung der K1057 bei der Panzerkaserne B\u00f6blingen wahrscheinlich mit einer Br\u00fccke.",
+            "source": "https://de.wikipedia.org/wiki/Radschnellwege_in_Baden-W%C3%BCrttemberg"
+        },
+        "stakeholders": [
+            {
+                "name": "Landeshauptstadt Stuttgart",
+                "roles": [
+                    "authority"
+                ]
+            }
+        ],
+        "references": {
+            "website": ""
+        }
+    }
+]

--- a/data/schema/meta.schema.json
+++ b/data/schema/meta.schema.json
@@ -16,7 +16,11 @@
         "from": { "type": "string" },
         "to": { "type": "string" },
         "description": { "type": "string" },
-        "slug": { "type": "string", "description": "Defines an URL slug", "format": "uri-reference" }
+        "slug": {
+          "type": "string",
+          "description": "Defines an URL slug",
+          "format": "uri-reference"
+        }
       },
       "required": ["from", "to", "slug"]
     },
@@ -46,7 +50,14 @@
       ]
     },
     "status": {
-      "enum": ["idea", "agreed", "planning", "in_progress", "done", "discarded"]
+      "enum": [
+        "idea",
+        "agreement_process",
+        "planning",
+        "in_progress",
+        "done",
+        "discarded"
+      ]
     },
     "planning_phase": {
       "enum": [

--- a/src/radschnellwege/geometry/24_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/24_baden_wuerttemberg.json
@@ -12,7 +12,7 @@
       "properties": {
         "id": "1",
         "detail_level": "corridor",
-        "state": "agreed",
+        "state": "agreement_process",
         "id_rsv": "24-baden-wuerttemberg",
         "planning_phase": null,
         "variant": "Vorzugstrasse",

--- a/src/radschnellwege/geometry/9_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/9_baden_wuerttemberg.json
@@ -12,7 +12,7 @@
       "properties": {
         "id": "1",
         "detail_level": "corridor",
-        "state": "agreed",
+        "state": "agreement_process",
         "id_rsv": "9-baden-wuerttemberg",
         "planning_phase": "preliminary",
         "variant": "Vorzugstrasse",

--- a/src/radschnellwege/geometry/rs17_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/rs17_baden_wuerttemberg.json
@@ -12,7 +12,7 @@
       "properties": {
         "id": "1",
         "detail_level": "rough",
-        "state": "agreed",
+        "state": "agreement_process",
         "id_rsv": "RS17",
         "planning_phase": "preliminary",
         "variant": "Vorzugstrasse",

--- a/src/radschnellwege/geometry/rs9_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/rs9_baden_wuerttemberg.json
@@ -14,7 +14,7 @@
       "properties": {
         "id": "1",
         "detail_level": "corridor",
-        "state": "agreed",
+        "state": "agreement_process",
         "id_rsv": "RS9",
         "planning_phase": "pilot",
         "variant": "Vorzugstrasse",
@@ -129,7 +129,7 @@
       "properties": {
         "id": "1",
         "detail_level": null,
-        "state": "agreed",
+        "state": "agreement_process",
         "id_rsv": "RS9",
         "planning_phase": null,
         "variant": "Alternative Vorzugstrasse",

--- a/src/radschnellwege/meta/meta.json
+++ b/src/radschnellwege/meta/meta.json
@@ -1,5 +1,29 @@
 [
   {
+    "id": "rs1-baden-w\u00fcrttemberg",
+    "cost": "drei Millionen Euro",
+    "finished": "",
+    "state": "in_progress",
+    "general": {
+      "ref": "RS1",
+      "name": "Radschnellweg B\u00f6blingen/Sindelfingen  \u2013 Stuttgart",
+      "from": "B\u00f6blingen",
+      "to": "Stuttgart",
+      "length": "20",
+      "description": "Anbindung der St\u00e4dte B\u00f6blingen und Sindelfingen f\u00fcr Radpendler an das Oberzentrum Stuttgart. In einem Bauabschnitt von acht Kilometern L\u00e4nge wurde die gepflasterte R\u00f6merstra\u00dfe auf vier Meter Breite asphaltiert und mit einer Beleuchtung versehen. Der Ausbau kostete drei Millionen Euro und wurde im Fr\u00fchjahr 2019 fertiggestellt. Der Sindelfinger Zweig f\u00fchrt von der Mahdentalstra\u00dfe \u00fcber den M\u00f6nchsbrunnen und das Musberger Str\u00e4\u00dfle bis zur R\u00f6merstra\u00dfe. Auf 80 Meter Strecke bleibt aus Gr\u00fcnden des Denkmalschutzes das historische Pflaster sichtbar. In Planung: eine bessere \u00dcberquerung der K1057 bei der Panzerkaserne B\u00f6blingen wahrscheinlich mit einer Br\u00fccke.",
+      "source": "https://de.wikipedia.org/wiki/Radschnellwege_in_Baden-W%C3%BCrttemberg"
+    },
+    "stakeholders": [
+      {
+        "name": "Landeshauptstadt Stuttgart",
+        "roles": ["authority"]
+      }
+    ],
+    "references": {
+      "website": ""
+    }
+  },
+  {
     "id": "rs2-baden-wuerttemberg",
     "cost": "zw\u00f6lf Millionen Euro (Erste grobe Kostensch\u00e4tzungen)",
     "finished": "",

--- a/src/radschnellwege/meta/meta.json
+++ b/src/radschnellwege/meta/meta.json
@@ -75,7 +75,7 @@
     "id": "rs5-baden-wuerttemberg",
     "cost": "",
     "finished": "",
-    "state": "agreed",
+    "state": "agreement_process",
     "general": {
       "ref": "RS5",
       "name": "Radschnellweg Schorndorf - Fellbach",
@@ -507,7 +507,7 @@
     "id": "9-baden-wuerttemberg",
     "cost": "",
     "finished": "",
-    "state": "agreed",
+    "state": "agreement_process",
     "general": {
       "ref": "9",
       "name": "Radschnellverbindung Vaihingen/Enz - Stuttgart",
@@ -819,7 +819,7 @@
     "id": "24-baden-wuerttemberg",
     "cost": "",
     "finished": "",
-    "state": "agreed",
+    "state": "agreement_process",
     "general": {
       "ref": "24",
       "name": "Radschnellweg Offenburg \u2013 Strasbourg",

--- a/src/radschnellwege/meta/meta.json
+++ b/src/radschnellwege/meta/meta.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "rs1-baden-w\u00fcrttemberg",
+    "id": "rs1-baden-wuerttemberg",
     "cost": "drei Millionen Euro",
     "finished": "",
     "state": "in_progress",


### PR DESCRIPTION
The `state` attribute on some GeoJSON files was still `agreed` instead of `agreement_process`.
It also adds the missing `rsv1-baden-wuerttemberg` to the meta.json

See #75 for an idea how to avoid this in future data imports