### PR TITLE
Abbrevation in SEO, unique key fix, illegal DOM-nesting fix

### DIFF
--- a/src/components/Map/DynamicMap.tsx
+++ b/src/components/Map/DynamicMap.tsx
@@ -54,9 +54,18 @@ export const DynamicMap: React.FC<Props> = ({ geometry }) => {
       // onMouseEnter={() => setCursorStyle('pointer')}
       // onMouseLeave={() => setCursorStyle('grab')}
     >
-      {geometry.features.map((feature) => (
-        <RSVSegment key={feature.id} feature={feature} selected={selected} />
-      ))}
+      {
+        geometry.features.map((feature) => (
+          <RSVSegment
+            key={`${
+              feature.properties.id_rsv
+            }_${feature.properties.length.toString()}`}
+            feature={feature}
+            selected={selected}
+          />
+        ))
+        // TODO: use id as key instead of length and name
+      }
       <RSVPopup info={info} selected={selected} setSelected={setSelected} />
     </Map>
   );

--- a/src/components/Map/DynamicMap.tsx
+++ b/src/components/Map/DynamicMap.tsx
@@ -54,18 +54,13 @@ export const DynamicMap: React.FC<Props> = ({ geometry }) => {
       // onMouseEnter={() => setCursorStyle('pointer')}
       // onMouseLeave={() => setCursorStyle('grab')}
     >
-      {
-        geometry.features.map((feature) => (
-          <RSVSegment
-            key={`${
-              feature.properties.id_rsv
-            }_${feature.properties.length.toString()}`}
-            feature={feature}
-            selected={selected}
-          />
-        ))
-        // TODO: use id as key instead of length and name
-      }
+      {geometry.features.map((feature) => (
+        <RSVSegment
+          key={feature.properties.id}
+          feature={feature}
+          selected={selected}
+        />
+      ))}
       <RSVPopup info={info} selected={selected} setSelected={setSelected} />
     </Map>
   );

--- a/src/pages/steckbriefe/index.tsx
+++ b/src/pages/steckbriefe/index.tsx
@@ -41,13 +41,13 @@ const SteckbriefeIndex: React.FC<PageProps & Props> = ({
             <h1 className="text-4xl font-extrabold tracking-tight text-white md:text-5xl lg:text-6xl">
               Übersicht über RSV-Planungen
             </h1>
-            <p className="mt-6 max-w-3xl text-xl text-slate-300">
+            <div className="mt-6 max-w-3xl text-xl text-slate-300">
               Übersicht der aktuell geplanten Radschnellverbindungen sowie deren
               Trassenverläufe bzw. -korridore. Enthalten sind RSV aus Hessen,
               Baden-Württemberg, Berlin, Niedersachsen, Schleswig-Holstein,
               Mecklenburg-Vorpommern, Nordrhein-Westfalen, Rheinland-Pfalz und
               Hamburg. Aktuell umfasst die Liste {radschnellwege.nodes.length}{' '}
-              Radschnellverbindungen und wird fortlaufend erweitert.{' '}
+              Radschnellverbindungen und wird fortlaufend erweitert.
               <p>
                 Mail an{' '}
                 <MailToButtonLink
@@ -59,7 +59,7 @@ const SteckbriefeIndex: React.FC<PageProps & Props> = ({
                 </MailToButtonLink>{' '}
                 schreiben
               </p>
-            </p>
+            </div>
           </div>
         </div>
 

--- a/src/pages/steckbriefe/{metaJson.jsonId}.tsx
+++ b/src/pages/steckbriefe/{metaJson.jsonId}.tsx
@@ -14,10 +14,13 @@ type Props = {
 };
 
 const Radschnellweg: React.FC<Props> = ({ data: { meta, geometry } }) => {
+  const name = Number.isNaN(parseFloat(meta.general.ref))
+    ? `${meta.general.ref}: ${meta.general.name}`
+    : meta.general.name;
   return (
     <Layout>
       <HelmetSeo
-        title={meta.general.name}
+        title={name}
         description={meta.general.description}
         image={`${domain()}${meta.staticMap.publicURL}`}
       />

--- a/src/radschnellwege/geometry/rs1_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/rs1_baden_wuerttemberg.json
@@ -88,7 +88,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "1",
+        "id": "2",
         "detail_level": "exact",
         "state": "done",
         "id_rsv": "RS1",
@@ -296,7 +296,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "1",
+        "id": "3",
         "detail_level": "exact",
         "state": "done",
         "id_rsv": "RS1",
@@ -460,7 +460,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "1",
+        "id": "4",
         "detail_level": "exact",
         "state": "done",
         "id_rsv": "RS1",
@@ -642,7 +642,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "1",
+        "id": "5",
         "detail_level": "exact",
         "state": "done",
         "id_rsv": "RS1",

--- a/src/radschnellwege/geometry/rs9_baden_wuerttemberg.json
+++ b/src/radschnellwege/geometry/rs9_baden_wuerttemberg.json
@@ -127,7 +127,7 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "1",
+        "id": "2",
         "detail_level": "",
         "state": "agreement_process",
         "id_rsv": "RS9",


### PR DESCRIPTION
- Display the RSV abbreviation (if available) in site title  for better SEO
- Add a unique key for every RSV segment
-  Fix illegal DOM-nesting on RSV overview page